### PR TITLE
Port VBI/T42 parsing improvements from teletext repository

### DIFF
--- a/lib/Constants.cs
+++ b/lib/Constants.cs
@@ -75,6 +75,46 @@ public class Constants
     /// Second framing code offset position in VBI data.
     /// </summary>
     public const int VBI_FRAMING_OFFSET_2 = 40;
+    /// <summary>
+    /// Parity lookup table for O(1) parity checking.
+    /// Returns true (1) if byte has odd parity (odd number of set bits).
+    /// Used for VBI decoding error correction.
+    /// </summary>
+    public static readonly byte[] VBI_PARITY_TABLE =
+    [
+        // 0x00-0x0F
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0x10-0x1F
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0x20-0x2F
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0x30-0x3F
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0x40-0x4F
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0x50-0x5F
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0x60-0x6F
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0x70-0x7F
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0x80-0x8F
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0x90-0x9F
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0xA0-0xAF
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0xB0-0xBF
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0xC0-0xCF
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0,
+        // 0xD0-0xDF
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0xE0-0xEF
+        1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
+        // 0xF0-0xFF
+        0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0
+    ];
     #endregion
 
     #region T42toVBI Constants

--- a/lib/Constants.cs
+++ b/lib/Constants.cs
@@ -182,25 +182,50 @@ public class Constants
     /// </summary>
     public const byte T42_BLOCK_START_BYTE = 0x0B;
     /// <summary>
-    /// Background control character code for T42 teletext display.
+    /// Background control character code for T42 teletext display (New Background - 0x1D).
+    /// Sets background color to current foreground color.
     /// </summary>
-    public const byte T42_BACKGROUND_CONTROL = 29;
+    public const byte T42_BACKGROUND_CONTROL = 0x1D;
     /// <summary>
-    /// Normal height control character code for T42 teletext display.
+    /// Black background control character code for T42 teletext display (0x1C).
+    /// Resets background to black.
     /// </summary>
-    public const byte T42_NORMAL_HEIGHT = 10;
+    public const byte T42_BLACK_BACKGROUND = 0x1C;
+    /// <summary>
+    /// Normal height control character code for T42 teletext display (End Box - 0x0A).
+    /// </summary>
+    public const byte T42_NORMAL_HEIGHT = 0x0A;
+    /// <summary>
+    /// Graphics foreground color range start (0x10).
+    /// </summary>
+    public const byte T42_GRAPHICS_COLOR_START = 0x10;
+    /// <summary>
+    /// Graphics foreground color range end (0x17).
+    /// </summary>
+    public const byte T42_GRAPHICS_COLOR_END = 0x17;
     /// <summary>
     /// ANSI escape sequence for resetting terminal formatting.
     /// </summary>
     public const string T42_ANSI_RESET = "\x1b[0m";
     /// <summary>
-    /// ANSI escape sequence for default T42 colors (white foreground, black background).
+    /// Teletext 3-bit colors mapped to ANSI 256-color palette for terminal-theme-independent display.
+    /// Index: 0=Black, 1=Red, 2=Green, 3=Yellow, 4=Blue, 5=Magenta, 6=Cyan, 7=White
+    /// These explicit color codes ensure consistent display regardless of terminal color scheme.
     /// </summary>
-    public const string T42_DEFAULT_COLORS = "\x1b[37m\x1b[40m";
+    public static readonly int[] T42_ANSI_256_COLORS = [16, 196, 46, 226, 21, 201, 51, 231];
     /// <summary>
-    /// Pre-formatted blank line with default T42 colors and spacing.
+    /// ANSI escape sequence for default T42 colors using 256-color palette (white foreground, black background).
+    /// Uses explicit 256-color codes to ensure colors are not affected by terminal themes.
     /// </summary>
-    public const string T42_BLANK_LINE = "\x1b[37m\x1b[40m                                        \x1b[0m";
+    public const string T42_DEFAULT_COLORS = "\x1b[38;5;231m\x1b[48;5;16m";
+    /// <summary>
+    /// Pre-formatted blank line with default T42 colors and spacing (40 characters).
+    /// </summary>
+    public const string T42_BLANK_LINE = "\x1b[38;5;231m\x1b[48;5;16m                                        \x1b[0m";
+    /// <summary>
+    /// Display width for teletext content (40 characters per line).
+    /// </summary>
+    public const int T42_DISPLAY_WIDTH = 40;
     #endregion
 
     #region TS Constants

--- a/lib/Functions.cs
+++ b/lib/Functions.cs
@@ -1262,6 +1262,27 @@ public class Functions
     }
 
     /// <summary>
+    /// Halve the length of a byte array by averaging adjacent samples.
+    /// Used for VBID (1440-byte) to VBI (720-byte) conversion to ensure
+    /// consistent processing through the standard VBI decode pipeline.
+    /// </summary>
+    /// <param name="bytes">The byte array to halve (typically 1440 bytes).</param>
+    /// <returns>The halved byte array (typically 720 bytes).</returns>
+    public static byte[] Halve(byte[] bytes)
+    {
+        // Create a new byte array with half the length of the input
+        var halved = new byte[bytes.Length / 2];
+        // For each byte in the output...
+        for (var i = 0; i < halved.Length; i++)
+        {
+            // Set the byte to the average of adjacent samples
+            halved[i] = (byte)((bytes[i * 2] + bytes[i * 2 + 1]) / 2);
+        }
+        // Return the halved bytes
+        return halved;
+    }
+
+    /// <summary>
     /// Normalise a byte array
     /// </summary>
     /// <param name="line">The byte array to normalise.</param>
@@ -1318,27 +1339,14 @@ public class Functions
     }
 
     /// <summary>
-    /// Check if a byte has odd parity
+    /// Check if a byte has odd parity using O(1) lookup table.
     /// </summary>
     /// <param name="value">The byte to check.</param>
-    /// <returns>True if the byte has odd parity, false otherwise.</returns>
+    /// <returns>True if the byte has odd parity (odd number of set bits), false otherwise.</returns>
     public static bool HasOddParity(byte value)
     {
-        // Set count to 0
-        var count = 0;
-
-        // For each bit in the byte...
-        for (var i = 0; i < 8; i++)
-        {
-            // If the bit is 1, increment the count
-            if ((value & (1 << i)) != 0)
-            {
-                count++;
-            }
-        }
-
-        // Return true if the count of '1' bits is odd
-        return count % 2 != 0;
+        // Use parity lookup table for O(1) lookup instead of counting bits
+        return Constants.VBI_PARITY_TABLE[value] == 1;
     }
 
     /// <summary>

--- a/lib/Handlers/ANCHandler.cs
+++ b/lib/Handlers/ANCHandler.cs
@@ -35,7 +35,8 @@ public class ANCHandler : IPacketFormatHandler
 
         // Use default rows if not specified
         var rows = options.Rows ?? Constants.DEFAULT_ROWS;
-        var outputFormat = options.OutputFormat;
+        // ANC is a container format; default to T42 for line parsing since ANC data contains T42
+        var outputFormat = options.OutputFormat == Format.ANC ? Format.T42 : options.OutputFormat;
         var lineNumber = 0;
         var timecode = options.StartTimecode ?? new Timecode(0);
 
@@ -100,7 +101,8 @@ public class ANCHandler : IPacketFormatHandler
         ArgumentNullException.ThrowIfNull(options);
 
         var rows = options.Rows ?? Constants.DEFAULT_ROWS;
-        var outputFormat = options.OutputFormat;
+        // ANC is a container format; default to T42 for line parsing since ANC data contains T42
+        var outputFormat = options.OutputFormat == Format.ANC ? Format.T42 : options.OutputFormat;
         int lineNumber = 0;
         var timecode = options.StartTimecode ?? new Timecode(0);
 

--- a/lib/Handlers/T42Handler.cs
+++ b/lib/Handlers/T42Handler.cs
@@ -78,7 +78,9 @@ public class T42Handler : ILineFormatHandler
             {
                 line.Magazine = T42.GetMagazine(t42Buffer[0]);
                 line.Row = T42.GetRow([.. t42Buffer.Take(2)]);
-                line.Text = T42.GetText([.. t42Buffer.Skip(2)], line.Row == 0);
+                // For header rows (row 0), extract and display page number
+                var pageNumber = line.Row == 0 ? T42.GetPageNumber(t42Buffer) : null;
+                line.Text = T42.GetText([.. t42Buffer.Skip(2)], line.Row == 0, line.Magazine, pageNumber);
             }
             else
             {
@@ -195,7 +197,9 @@ public class T42Handler : ILineFormatHandler
                 {
                     line.Magazine = T42.GetMagazine(line.Data[0]);
                     line.Row = T42.GetRow([.. line.Data.Take(2)]);
-                    line.Text = T42.GetText([.. line.Data.Skip(2)], line.Row == 0);
+                    // For header rows (row 0), extract and display page number
+                    var pageNumber = line.Row == 0 ? T42.GetPageNumber(line.Data) : null;
+                    line.Text = T42.GetText([.. line.Data.Skip(2)], line.Row == 0, line.Magazine, pageNumber);
                 }
                 else
                 {

--- a/lib/Handlers/VBIHandler.cs
+++ b/lib/Handlers/VBIHandler.cs
@@ -91,6 +91,9 @@ public class VBIHandler : ILineFormatHandler
             }
 
             // Create Line object with T42 metadata
+            var magazine = T42.GetMagazine(t42Data[0]);
+            var row = T42.GetRow([.. t42Data.Take(2)]);
+            var pageNumber = row == 0 ? T42.GetPageNumber(t42Data) : null;
             var line = new Line()
             {
                 LineNumber = lineNumber,
@@ -99,9 +102,9 @@ public class VBIHandler : ILineFormatHandler
                 SampleCoding = 0x31,
                 SampleCount = t42Data.Length,
                 LineTimecode = timecode,
-                Magazine = T42.GetMagazine(t42Data[0]),
-                Row = T42.GetRow([.. t42Data.Take(2)]),
-                Text = T42.GetText([.. t42Data.Skip(2)], T42.GetRow([.. t42Data.Take(2)]) == 0)
+                Magazine = magazine,
+                Row = row,
+                Text = T42.GetText([.. t42Data.Skip(2)], row == 0, magazine, pageNumber)
             };
 
             // Apply filtering (works for all output formats since we have T42 metadata)
@@ -226,6 +229,9 @@ public class VBIHandler : ILineFormatHandler
                 }
 
                 // Create Line object with T42 metadata
+                var magazine = T42.GetMagazine(t42Data[0]);
+                var row = T42.GetRow([.. t42Data.Take(2)]);
+                var pageNumber = row == 0 ? T42.GetPageNumber(t42Data) : null;
                 var line = new Line()
                 {
                     LineNumber = lineNumber,
@@ -234,9 +240,9 @@ public class VBIHandler : ILineFormatHandler
                     SampleCoding = 0x31,
                     SampleCount = t42Data.Length,
                     LineTimecode = timecode,
-                    Magazine = T42.GetMagazine(t42Data[0]),
-                    Row = T42.GetRow([.. t42Data.Take(2)]),
-                    Text = T42.GetText([.. t42Data.Skip(2)], T42.GetRow([.. t42Data.Take(2)]) == 0)
+                    Magazine = magazine,
+                    Row = row,
+                    Text = T42.GetText([.. t42Data.Skip(2)], row == 0, magazine, pageNumber)
                 };
 
                 // Apply filtering (works for all output formats since we have T42 metadata)

--- a/lib/Line.cs
+++ b/lib/Line.cs
@@ -474,7 +474,9 @@ public class Line : IDisposable
                 {
                     Magazine = T42.GetMagazine(Data[0]);
                     Row = T42.GetRow([.. Data.Take(2)]);
-                    Text = T42.GetText([.. Data.Skip(2)], Row == 0);
+                    // For header rows (row 0), extract and display page number
+                    var pageNumber = Row == 0 ? T42.GetPageNumber(Data) : null;
+                    Text = T42.GetText([.. Data.Skip(2)], Row == 0, Magazine, pageNumber);
                 }
                 else
                 {


### PR DESCRIPTION
This commit brings improvements from the nathanpbutler/teletext repository:

- Use ANSI 256-color palette for terminal-theme-independent display
  - Colors now display consistently regardless of terminal color scheme
  - Explicit color codes (16, 196, 46, 226, 21, 201, 51, 231) for teletext colors

- Implement proper teletext Set-After color model
  - Pending foreground/background colors apply to NEXT character
  - Box depth tracking for Start Box (0x0B) and End Box (0x0A)
  - Proper color reset when all boxes are closed

- Add page header display with magazine/page number (P801 format)
  - New GetPageNumber() method to decode page numbers from header rows
  - Header rows display as "P{magazine}{page}" (e.g., "P801")

- Add G0 Latin character set mapping for special teletext characters
  - Proper mapping of £, ←, ½, →, ↑, #, —, ¼, ‖, ¾, ÷, █

- Add new constants for teletext control codes
  - T42_BLACK_BACKGROUND (0x1C)
  - T42_GRAPHICS_COLOR_START/END (0x10-0x17)
  - T42_DISPLAY_WIDTH (40)
  - T42_ANSI_256_COLORS array